### PR TITLE
setupTemplate.sh skal ikke kjøre sed på filer under .git/

### DIFF
--- a/setupTemplate.sh
+++ b/setupTemplate.sh
@@ -40,7 +40,7 @@ mkdir -p "src/main/kotlin/no/nav/sokos/$artifactNamePath"
 mkdir -p "src/test/kotlin/no/nav/sokos/$artifactNamePath"
 
 # Combine grep commands
-grep -rl --exclude=setupTemplate.sh -e $default -e $defaultArtifactName -e "sokos_ktor_template" -e "sokos_ktor_template_type" | xargs -I@ sed -i '' -e "s|$default|$projectName|g" -e "s|$defaultArtifactName|$artifactName|g" -e "s|sokos_ktor_template|$projectNameWithUnderScore|g" -e "s|sokos_ktor_template_type|${projectNameWithUnderScore}_type|g" @
+grep -rl --exclude=setupTemplate.sh --exclude-dir=.git -e $default -e $defaultArtifactName -e "sokos_ktor_template" -e "sokos_ktor_template_type" | xargs -I@ sed -i '' -e "s|$default|$projectName|g" -e "s|$defaultArtifactName|$artifactName|g" -e "s|sokos_ktor_template|$projectNameWithUnderScore|g" -e "s|sokos_ktor_template_type|${projectNameWithUnderScore}_type|g" @
 
 # Move files from the old directory to the new one
 mv src/main/kotlin/no/nav/sokos/prosjektnavn/* "src/main/kotlin/no/nav/sokos/$artifactNamePath"


### PR DESCRIPTION
Før denne endringen fikk jeg følgende oppførsel:

```
 …/sokos-ktor-template  ( echo foo-bar; echo foobar ) | bash setupTemplate.sh
**** Setup for sokos-ktor-template ****


sed: RE error: illegal byte sequence
```

... mens etter at .git/ blir ekskludert fra grep, så har sed-feilen blitt borte (og formodentlig risikerer man ikke lenger at noe dypt nede under .git/ blir korrumpert av sed).