### PR TITLE
Add Copilot skills, HOCON config refactor, and coding conventions

### DIFF
--- a/.copilot/skills/azure-rbac-ktor/REFERENCE.md
+++ b/.copilot/skills/azure-rbac-ktor/REFERENCE.md
@@ -1,0 +1,63 @@
+# Reference: Azure RBAC in Ktor
+
+## Code structure
+
+```
+security/
+├── AccessPolicy.kt        # Scope and Role enums + validation
+├── AuthorizationGuard.kt  # Extension functions on ApplicationCall
+└── TokenUtils.kt          # Helper: extract app name from JWT
+```
+
+## Authorization flow
+
+```
+Incoming request
+       │
+       ▼
+  Ktor auth plugin (JWT validation against Azure JWKS)
+       │
+       ▼
+  requirePermission() / requireScope() / requireRole()
+       │
+       ├─── OBO token? ──► check `scp` claim against Scope.ALLOWED_SCOPES
+       │                         │
+       │                    ✅ match → allow
+       │                    ❌ no match → check M2M
+       │
+       └─── M2M token? ──► check `roles` claim against Role.ALLOWED_ROLES
+                                 │
+                            ✅ match → allow
+                            ❌ no match → throw AuthorizationException (→ 403)
+```
+
+## NAIS double-check
+
+The NAIS platform enforces `accessPolicy` at network level (mTLS). The code check in `AuthorizationGuard` is an **additional layer** at application level — both must pass for the call to go through.
+
+Troubleshooting order for 403:
+1. Is the calling app's `application` name correct in `accessPolicy.inbound.rules`?
+2. Is the desired scope/role listed under `permissions` for that app?
+3. Does the route use the correct `requirePermission`/`requireScope`/`requireRole`?
+4. Does the string value in the `Scope`/`Role` enum match what is configured in NAIS?
+
+## API overview
+
+```kotlin
+// Check OBO scope OR M2M role (recommended for most endpoints)
+call.requirePermission(requiredScope: Scope, requiredRole: Role)
+
+// Check OBO scope only
+call.requireScope(requiredScope: Scope)
+
+// Check M2M role only
+call.requireRole(requiredRole: Role)
+
+// Get NAVident from OBO token (null for M2M)
+call.getNavIdentOrNull(): String?
+
+// Get app name from azp_name/client_id
+call.getCallingSystem(): String
+```
+
+All functions throw `AuthorizationException` (→ HTTP 403) on missing access.

--- a/.copilot/skills/azure-rbac-ktor/SKILL.md
+++ b/.copilot/skills/azure-rbac-ktor/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: azure-rbac-ktor
+description: "Role-based access control (RBAC) with Azure AD in Ktor services on NAIS. Use when adding endpoints with access control, defining new roles/scopes, or configuring accessPolicy in NAIS manifests. Accepts prompts in Norwegian and English. (Rollebasert tilgangsstyring, tilgangskontroll, endepunkter, roller, scopes, Nais-manifest)"
+---
+
+# Azure RBAC in Ktor
+
+## Overview
+
+Access control distinguishes between two token types:
+
+| Token type | Source | JWT claim | Use case |
+|-----------|-------|-----------|----------|
+| **OBO** (On-Behalf-Of) | User via frontend | `scp` | Case worker calls API |
+| **M2M** (Machine-to-Machine) | System without user | `roles` | Another service calls directly |
+
+## 1. Define scopes and roles
+
+Add new values in `AccessPolicy.kt`:
+
+```kotlin
+enum class Scope(val value: String) {
+    READ_DATA_SCOPE("read-data-scope"),
+    WRITE_DATA_SCOPE("write-data-scope"),
+    // add new scopes here
+}
+
+enum class Role(val value: String) {
+    READ_DATA_ROLE("read-data-role"),
+    WRITE_DATA_ROLE("write-data-role"),
+    // add new roles here
+}
+```
+
+String values **must** exactly match what is configured in the NAIS manifest.
+
+## 2. Protect endpoints in Ktor
+
+Use extension functions from `AuthorizationGuard` inside routes:
+
+```kotlin
+// OBO OR M2M — most common pattern
+get("/data/{id}") {
+    call.requirePermission(
+        requiredScope = Scope.READ_DATA_SCOPE,
+        requiredRole  = Role.READ_DATA_ROLE,
+    )
+    // business logic
+}
+
+// OBO only (user context required)
+post("/submit") {
+    call.requireScope(Scope.WRITE_DATA_SCOPE)
+    val navIdent = call.getNavIdentOrNull()   // log who performed the action
+}
+
+// M2M only (system call)
+post("/ingest") {
+    call.requireRole(Role.WRITE_DATA_ROLE)
+    val system = call.getCallingSystem()      // log which app called
+}
+```
+
+## 3. Configure NAIS manifest
+
+Add each calling system under `accessPolicy.inbound.rules` with **only** the scopes/roles it actually needs:
+
+```yaml
+azure:
+  application:
+    enabled: true
+    allowAllUsers: true
+    claims:
+      extra:
+        - NAVident          # required for OBO tokens
+
+accessPolicy:
+  inbound:
+    rules:
+      - application: my-frontend-app
+        permissions:
+          scopes:
+            - "read-data-scope"
+
+      - application: my-batch-service
+        permissions:
+          roles:
+            - "read-data-role"
+
+      - application: external-app
+        namespace: other-team
+        cluster: prod-gcp    # only for cross-cluster
+        permissions:
+          roles:
+            - "write-data-role"
+```
+
+## 4. Logging and audit
+
+`getCallingSystem()` extracts the app name from `azp_name`/`client_id` and strips the cluster/namespace prefix:
+
+```
+"dev-gcp:okonomi:my-calling-app" → "my-calling-app"
+```
+
+Always log `navIdent` or `callingSystem` — never fnr/PII.
+
+## Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| 403 despite valid token | Scope/role missing in NAIS manifest | Add under `permissions` for the correct app |
+| 403 despite NAIS access | Scope string doesn't match enum | Verify `Scope.value == permissions.scope` exactly |
+| `NAVident` missing | `claims.extra` not set | Add `- NAVident` under `claims.extra` |
+| M2M token gets OBO error | Wrong `requireScope` instead of `requirePermission` | Use `requirePermission` to support both |
+
+## See also
+
+- [REFERENCE.md](REFERENCE.md) — detailed flow description and code structure

--- a/.copilot/skills/kotest/SKILL.md
+++ b/.copilot/skills/kotest/SKILL.md
@@ -30,6 +30,7 @@ Default spec style: **`BehaviorSpec`** (Given/When/Then/And) with Norwegian scen
 ## Boundaries
 
 ### ✅ Always
+- `testApplication { }` exclusively for testing API endpoints (routes) — never for services, repositories, or other non-HTTP logic
 - `BehaviorSpec` as default; Norwegian scenario text
 - Reset circuit breaker in `beforeEach` when tests reach an external HTTP client
 - Clear database state before loading fixtures in each `Given`
@@ -42,6 +43,7 @@ Default spec style: **`BehaviorSpec`** (Given/When/Then/And) with Norwegian scen
 - Tests requiring real network or real SFTP
 
 ### 🚫 Never
+- `testApplication { }` for anything other than API endpoint tests (use direct class instantiation + mocks for services, repositories, etc.)
 - JUnit
 - `runBlocking { ... }` in test blocks
 - Real HTTP calls to external services

--- a/.copilot/skills/kotest/SKILL.md
+++ b/.copilot/skills/kotest/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: kotest
+description: "Kotest BehaviorSpec and MockK patterns for sokos Ktor services: scenario structure, test listeners, HTTP mocking, circuit-breaker reset, and matchers. Accepts prompts in Norwegian and English. (Testmønstre, teststruktur, integrasjonstester, enhetstester, MockK)"
+---
+
+# Kotest patterns
+
+## Coverage audit — ALWAYS do this first
+
+Before concluding that an area lacks tests, **always list all test files**:
+
+```bash
+find src/test -type f -name "*.kt" | sort
+```
+
+Tests may be organized in subcategories — never use `| head` which truncates output.
+
+Do not assume missing coverage without seeing the full file list first.
+
+---
+
+Default spec style: **`BehaviorSpec`** (Given/When/Then/And) with Norwegian scenario text. Use `FunSpec` only for trivial, non-scenario-based unit tests.
+
+## Sub-files
+
+- [behaviorspec-patterns.md](behaviorspec-patterns.md) — canonical BehaviorSpec structure, conventions, and Norwegian scenario text
+- [integration-testing.md](integration-testing.md) — database test listeners, SFTP listeners, mock HTTP clients, and circuit breaker reset
+- [mockk-assertions.md](mockk-assertions.md) — MockK cheat sheet, Kotest matchers, `with { ... }` grouping
+
+## Boundaries
+
+### ✅ Always
+- `BehaviorSpec` as default; Norwegian scenario text
+- Reset circuit breaker in `beforeEach` when tests reach an external HTTP client
+- Clear database state before loading fixtures in each `Given`
+- Mock HTTP clients for external service calls — never make real HTTP calls in tests
+- Kotest matchers (`shouldBe`, `shouldHaveSize`, …)
+- `coEvery` / `coVerify` for suspend functions
+
+### ⚠️ Ask first
+- New global test listeners or base specs
+- Tests requiring real network or real SFTP
+
+### 🚫 Never
+- JUnit
+- `runBlocking { ... }` in test blocks
+- Real HTTP calls to external services
+- Share mutable state between scenarios without explicit reset

--- a/.copilot/skills/kotest/behaviorspec-patterns.md
+++ b/.copilot/skills/kotest/behaviorspec-patterns.md
@@ -1,0 +1,44 @@
+# BehaviorSpec Patterns
+
+## Canonical BehaviorSpec
+
+```kotlin
+class MyServiceTest : BehaviorSpec({
+    val repositoryMock = mockk<MyRepository> {
+        justRun { saveResults(any<List<ProcessingResult>>()) }
+    }
+
+    Given("en ny forespørsel som skal behandles") {
+        val request = mockk<MyRequest>(relaxed = true) {
+            every { id } returns "test-id"
+            every { type } returns "STANDARD"
+        }
+
+        When("ekstern tjeneste svarer med 200 OK") {
+            val externalClientMock = mockk<ExternalClient> {
+                coEvery { submit(any(), any()) } returns
+                    HttpResponse(status = HttpStatusCode.OK, body = """{"ref": "123"}""")
+            }
+            val service = MyService(externalClientMock, repositoryMock)
+
+            val results = service.processAll(listOf(request))
+
+            Then("skal det returneres ett resultat med status COMPLETED") {
+                results.shouldHaveSize(1)
+                results.first().status shouldBe Status.COMPLETED
+                results.first().reference shouldBe "123"
+            }
+            And("repository skal lagre resultatet") {
+                verify(exactly = 1) { repositoryMock.saveResults(any<List<ProcessingResult>>()) }
+            }
+        }
+    }
+})
+```
+
+## Conventions
+
+- Norwegian Given/When/Then/And text
+- Test data in `Given`, scenario-specific mocks in `When`, shared fixtures on spec top-level
+- One `When` per causal step; multiple `Then`/`And` for independent assertions
+- Never `runBlocking` inside test blocks — use `coEvery` / `coVerify`

--- a/.copilot/skills/kotest/integration-testing.md
+++ b/.copilot/skills/kotest/integration-testing.md
@@ -1,0 +1,84 @@
+# Integration Testing
+
+## Database integration tests
+
+Use a `TestListener` that manages a TestContainers database instance. Example pattern:
+
+```kotlin
+internal class MyServiceIntegrationTest : BehaviorSpec({
+    extensions(DBListener)
+    beforeEach { CircuitBreakerManager.circuitBreaker.reset() }
+
+    val dbService = MyDatabaseService(DBListener.dataSource)
+
+    Given("2 ubehandlede oppføringer i databasen") {
+        DBListener.clearDB()
+        DBListener.loadInitScript("SQLscript/two-pending-entries.sql")
+
+        val entries = dbService.getAllPending()
+        entries.shouldHaveSize(2)
+
+        When("ekstern tjeneste svarer med OK") {
+            val httpClient = MockHttpClient.client(
+                MockResponse(Endpoint.SUBMIT, successResponse("ref-123"), HttpStatusCode.OK),
+            )
+            val externalClient = ExternalClient("", httpClient, mockk(relaxed = true))
+            val results = MyService(externalClient, dbService).processAll(entries)
+
+            Then("alle oppføringer skal være behandlet") {
+                results.shouldHaveSize(2)
+                dbService.getAllPending().shouldBeEmpty()
+            }
+        }
+    }
+})
+```
+
+### Typical DBListener API
+
+| Helper | Purpose |
+|---|---|
+| `extensions(DBListener)` | Registers TestContainers PostgreSQL |
+| `DBListener.dataSource` | `HikariDataSource` with Flyway migrations applied |
+| `DBListener.clearDB()` | `TRUNCATE ... RESTART IDENTITY CASCADE` |
+| `DBListener.loadInitScript("SQLscript/...")` | Loads fixture from `src/test/resources/` |
+
+Always `clearDB()` before `loadInitScript(...)` inside each `Given` — listener state leaks between scenarios otherwise.
+
+## SFTP integration tests
+
+```kotlin
+internal class FtpServiceIntegrationTest : BehaviorSpec({
+    extensions(SftpListener)
+    // ...
+})
+```
+
+## Mock HTTP clients
+
+Build a mock HTTP client that matches by endpoint path and optionally installs plugins (e.g. circuit breaker) so tests exercise production wiring:
+
+```kotlin
+val client = MockHttpClient.client(
+    MockResponse(Endpoint.SUBMIT, successResponse("ref-123"), HttpStatusCode.OK),
+    MockResponse(Endpoint.STATUS, statusResponse(), HttpStatusCode.OK),
+)
+```
+
+For unit tests that don't need HTTP wiring, mock the client class directly:
+
+```kotlin
+val externalClientMock = mockk<ExternalClient> {
+    coEvery { submit(any(), any()) } returns mockHttpResponse(body = successResponse("123"))
+}
+```
+
+## Circuit breaker
+
+Every test that eventually reaches an external HTTP client with a circuit breaker must reset it — otherwise state leaks between tests:
+
+```kotlin
+beforeEach { CircuitBreakerManager.circuitBreaker.reset() }
+```
+
+When an open breaker is expected (e.g. after multiple error responses), verify with `coVerify(exactly = 1) { ... }` that further calls were suppressed.

--- a/.copilot/skills/kotest/mockk-assertions.md
+++ b/.copilot/skills/kotest/mockk-assertions.md
@@ -1,0 +1,31 @@
+# MockK & Assertions
+
+## MockK cheat sheet
+
+| Need | Pattern |
+|---|---|
+| Plain mock | `mockk<T>()` |
+| Relaxed (auto-stub everything) | `mockk<T>(relaxed = true)` |
+| Spy on real instance | `spyk(MyService(...), recordPrivateCalls = true)` |
+| Suspend stub | `coEvery { ... } returns ...` |
+| `Unit`-returning stub | `justRun { ... }` / `coJustRun { ... }` |
+| Verify | `verify(exactly = n) { ... }` / `coVerify { ... }` |
+| Private function stub | `every { spy["privateFun"](any<T>()) } returns ...` (needs `recordPrivateCalls = true`) |
+
+## Assertions
+
+Prefer Kotest matchers. Group related field checks with `with { ... }`:
+
+```kotlin
+result shouldBe expected
+list.shouldHaveSize(2)
+list.shouldBeEmpty()
+list.shouldContainExactly(a, b)
+exception.message shouldContain "missing field"
+
+with(result.first()) {
+    httpStatusCode shouldBe HttpStatusCode.OK
+    status shouldBe Status.COMPLETED
+    reference shouldBe "123"
+}
+```

--- a/.copilot/skills/kotlin-app-config/SKILL.md
+++ b/.copilot/skills/kotlin-app-config/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: kotlin-app-config
+description: "HOCON-based configuration with PropertiesConfig singleton for Ktor services on NAIS. Use when adding config sections, environment layering, or typed config classes. Accepts prompts in Norwegian and English. (Konfigurasjon, miljøvariabler, HOCON, PropertiesConfig, oppsett)"
+---
+
+# Kotlin Application Configuration Skill
+
+This skill describes the HOCON + `PropertiesConfig` singleton pattern for Ktor services on NAIS.
+Config is loaded from layered HOCON files via Ktor's `ApplicationConfig` API.
+
+## PropertiesConfig Singleton
+
+`PropertiesConfig` is a Kotlin `object` that holds all typed config sections as lazy properties.
+Call `PropertiesConfig.load(config)` once at startup; never re-initialize.
+
+```kotlin
+object PropertiesConfig {
+    lateinit var config: ApplicationConfig
+        private set
+
+    val isLocal: Boolean
+        get() = applicationProperties.isLocal
+
+    val applicationProperties by lazy {
+        config.property("application").getAs<ApplicationProperties>()
+    }
+
+    val postgresConfig by lazy {
+        config.property("postgres").getAs<PostgresConfig>()
+    }
+
+    // Add new config sections here as lazy properties
+
+    fun load(applicationConfig: ApplicationConfig) {
+        if (!::config.isInitialized) {
+            config = applicationConfig
+        }
+    }
+}
+```
+
+## Usage at Startup
+
+```kotlin
+private fun Application.module() {
+    PropertiesConfig.load(environment.config.mergeWithEnv())
+
+    val useAuthentication = PropertiesConfig.applicationProperties.useAuthentication
+
+    if (!PropertiesConfig.isLocal) {
+        // Run migrations, start scheduled jobs, etc.
+    }
+}
+```
+
+## Sub-files
+
+- See [hocon-layering.md](hocon-layering.md) for the layered HOCON pattern (`mergeWithEnv()`) and example HOCON config files.
+- See [config-classes.md](config-classes.md) for typed config section data classes (`@Serializable`) and testing configuration with MockK.
+
+## Benefits
+
+- **Single source of truth**: All config in one singleton, no passing config objects around
+- **Lazy initialization**: Config sections only parsed when first accessed
+- **Type safety**: `@Serializable data class` properties with compile-time field names
+- **Environment layering**: Local overrides without touching base config
+- **NAIS-native**: Aligns with the HOCON layering convention used across NAV services

--- a/.copilot/skills/kotlin-app-config/config-classes.md
+++ b/.copilot/skills/kotlin-app-config/config-classes.md
@@ -1,0 +1,58 @@
+# Typed Config Classes & Testing
+
+## Typed Config Section Data Classes
+
+Each config section is a `@Serializable data class` deserialized via Ktor's `getAs<T>()` extension.
+
+```kotlin
+enum class Profile { LOCAL, DEV, TEST, PROD }
+
+@Serializable
+data class ApplicationProperties(
+    val profile: Profile,
+    val appName: String,
+    val namespace: String,
+    val useAuthentication: Boolean,
+) {
+    val isLocal = profile == Profile.LOCAL
+}
+
+@Serializable
+data class PostgresConfig(
+    val host: String,
+    val port: String,
+    val name: String,
+    val username: String = "",
+    val password: String = "",
+) {
+    val adminUser = "$name-admin"
+    val user = "$name-user"
+}
+```
+
+Add new `@Serializable data class` config sections as your service needs them (e.g. external API credentials, SFTP settings, scheduler config). Register each one as a `by lazy` property in `PropertiesConfig`.
+
+## In Tests
+
+Load a fixed test config directly from `application-test.conf`:
+
+```kotlin
+object DBListener : TestListener {
+    init {
+        PropertiesConfig.load(ApplicationConfig("application-test.conf"))
+    }
+    // ...
+}
+```
+
+Mock `PropertiesConfig` with MockK when needed:
+
+```kotlin
+beforeSpec {
+    mockkObject(PropertiesConfig)
+    every { PropertiesConfig.config } returns ApplicationConfig("application-test.conf")
+}
+afterSpec {
+    unmockkObject(PropertiesConfig)
+}
+```

--- a/.copilot/skills/kotlin-app-config/hocon-layering.md
+++ b/.copilot/skills/kotlin-app-config/hocon-layering.md
@@ -19,7 +19,7 @@ fun ApplicationConfig.mergeWithEnv(): ApplicationConfig {
             ?: propertyOrNull("ktor.environment")?.getString()
             ?: "local"
     val environmentConfig = ApplicationConfig("application-$environment.conf")
-    return environmentConfig overriding this overriding hoconConfig
+    return this overriding environmentConfig overriding hoconConfig
 }
 
 infix fun ApplicationConfig.overriding(other: ApplicationConfig): ApplicationConfig =

--- a/.copilot/skills/kotlin-app-config/hocon-layering.md
+++ b/.copilot/skills/kotlin-app-config/hocon-layering.md
@@ -1,0 +1,61 @@
+# HOCON Layering & Example Config Files
+
+## Layered HOCON Pattern
+
+Config files are layered at startup via `mergeWithEnv()`:
+1. `application.conf` – base defaults, references `defaults.properties`
+2. `application-{local|dev|prod}.conf` – environment overrides
+3. `defaults.properties` – local secrets (**never commit this file**)
+
+Environment is detected via `NAIS_CLUSTER_NAME`:
+
+```kotlin
+fun ApplicationConfig.mergeWithEnv(): ApplicationConfig {
+    val hoconConfig = HoconApplicationConfig(ConfigFactory.load())
+    val environment =
+        (System.getenv("NAIS_CLUSTER_NAME") ?: System.getProperty("NAIS_CLUSTER_NAME"))
+            ?.lowercase()
+            ?.substringBefore("-")
+            ?: propertyOrNull("ktor.environment")?.getString()
+            ?: "local"
+    val environmentConfig = ApplicationConfig("application-$environment.conf")
+    return environmentConfig overriding this overriding hoconConfig
+}
+
+infix fun ApplicationConfig.overriding(other: ApplicationConfig): ApplicationConfig =
+    this.withFallback(other)
+```
+
+## Example HOCON Files
+
+**`application.conf`** (base):
+```hocon
+include file("defaults.properties")
+
+ktor {
+  environment = local
+}
+
+application {
+  appName = "my-app"
+  appName = ${?NAIS_APP_NAME}
+  namespace = "okonomi"
+  useAuthentication = true
+}
+
+postgres {
+  name = "my-app"
+  username = ${?POSTGRES_USERNAME}
+  password = ${?POSTGRES_PASSWORD}
+}
+```
+
+**`application-local.conf`** (local overrides):
+```hocon
+include file("application.conf")
+
+application {
+  profile = LOCAL
+  useAuthentication = false
+}
+```

--- a/.copilot/skills/kotlin-patterns/SKILL.md
+++ b/.copilot/skills/kotlin-patterns/SKILL.md
@@ -40,8 +40,11 @@ Idiomatic conventions for this codebase. Detailed examples live in the sub-files
 - `sealed` for modeled state
 - `suspend` + structured concurrency for async
 - Run `ktlintFormat` before committing
+- [navikt/kotliquery](https://github.com/navikt/kotliquery) for database access — our fork of Kotliquery
 
 ### 🚫 Never
+- ORM frameworks (Exposed, Spring Data, Hibernate, etc.) unless explicitly specified — use navikt/kotliquery
+- IOC/DI frameworks (Koin, Spring, Dagger, etc.) unless explicitly specified — use manual constructor injection
 - `runBlocking` in production code
 - `GlobalScope.launch`
 - `!!` without a preceding null check

--- a/.copilot/skills/kotlin-patterns/SKILL.md
+++ b/.copilot/skills/kotlin-patterns/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: kotlin-patterns
+description: "Idiomatic Kotlin patterns: null safety, immutability, sealed types, structured concurrency, extension functions, DSL builders, Gradle Kotlin DSL. Accepts prompts in Norwegian and English. (Kotlin-mønstre, idiomatisk Kotlin, null-sikkerhet, sealed class, koroutiner, Gradle)"
+---
+
+# Kotlin patterns
+
+Idiomatic conventions for this codebase. Detailed examples live in the sub-files — load them on demand.
+
+## Quick reference
+
+| Idiom | Use for |
+|---|---|
+| `val` over `var` | Default; prefer immutability |
+| `data class` / `copy()` | Value objects with equals/hashCode and non-destructive updates |
+| `sealed class/interface` | Restricted type hierarchies (state, results) |
+| `value class` | Zero-overhead type-safe wrappers |
+| Expression `when` | Exhaustive pattern matching |
+| `?.` / `?:` / `requireNotNull` | Null-safe access; avoid `!!` without a justified check |
+| `let` / `run` / `apply` / `also` / `with` | Scope functions for locality and readability |
+| Extension functions | Add behaviour without inheritance |
+| `require` / `check` | Preconditions for public API |
+| `suspend` + `coroutineScope` / `async` | Structured concurrency |
+| `Flow` | Cold reactive streams |
+| `sequence` | Lazy evaluation over collections |
+| Delegation `by` | Reuse without inheritance |
+
+## Sub-files
+
+- [core-patterns.md](core-patterns.md) — null safety, immutability, expression bodies, scope functions
+- [type-modeling.md](type-modeling.md) — sealed types, extensions, delegation
+- [coroutines.md](coroutines.md) — structured concurrency, Flow, cancellation
+- [dsl-and-gradle.md](dsl-and-gradle.md) — DSL builders (`@DslMarker`), Gradle Kotlin DSL
+- [error-handling.md](error-handling.md) — error patterns, collection operations, anti-patterns
+
+## Boundaries
+
+### ✅ Always
+- Null safety via types (`?`, `?.`, `?:`)
+- `sealed` for modeled state
+- `suspend` + structured concurrency for async
+- Run `ktlintFormat` before committing
+
+### 🚫 Never
+- `runBlocking` in production code
+- `GlobalScope.launch`
+- `!!` without a preceding null check
+- Ignore coroutine cancellation

--- a/.copilot/skills/kotlin-patterns/core-patterns.md
+++ b/.copilot/skills/kotlin-patterns/core-patterns.md
@@ -154,3 +154,22 @@ user?.let { u ->
 val city = user?.address?.city
 city?.let { println(it) }
 ```
+
+## Naming Convention
+
+All naming (functions, variables, classes, etc.) must be in **English**, except for **domain words** which stay in Norwegian.
+
+Domain words are business/domain-specific terms from NAV's vocabulary (e.g. `krav`, `utbetaling`, `oppdrag`, `attestasjon`). These are kept in Norwegian because translating them loses precision.
+
+```kotlin
+// Good: English naming with Norwegian domain words
+fun getKrav(kravId: String): Krav
+fun updateUtbetaling(utbetaling: Utbetaling): Utbetaling
+fun processOppdrag(oppdragList: List<Oppdrag>): List<Result>
+data class Attestasjon(val id: String, val status: AttestasjonStatus)
+
+// Bad: Norwegian verbs/structure
+fun hentKrav(kravId: String): Krav        // "hent" → "get"
+fun oppdaterUtbetaling(...): Utbetaling   // "oppdater" → "update"
+fun behandleOppdrag(...): List<Result>    // "behandle" → "process"
+```

--- a/.copilot/skills/kotlin-patterns/core-patterns.md
+++ b/.copilot/skills/kotlin-patterns/core-patterns.md
@@ -1,0 +1,156 @@
+# Core Patterns
+
+## 1. Null Safety
+
+Kotlin's type system distinguishes nullable and non-nullable types. Leverage it fully.
+
+```kotlin
+// Good: Use non-nullable types by default
+fun getUser(id: String): User {
+    return userRepository.findById(id)
+        ?: throw UserNotFoundException("User $id not found")
+}
+
+// Good: Safe calls and Elvis operator
+fun getUserEmail(userId: String): String {
+    val user = userRepository.findById(userId)
+    return user?.email ?: "unknown@example.com"
+}
+
+// Bad: Force-unwrapping nullable types
+fun getUserEmail(userId: String): String {
+    val user = userRepository.findById(userId)
+    return user!!.email // Throws NPE if null
+}
+```
+
+## 2. Immutability by Default
+
+Prefer `val` over `var`, immutable collections over mutable ones.
+
+```kotlin
+// Good: Immutable data
+data class User(
+    val id: String,
+    val name: String,
+    val email: String,
+)
+
+// Good: Transform with copy()
+fun updateEmail(user: User, newEmail: String): User =
+    user.copy(email = newEmail)
+
+// Good: Immutable collections
+val users: List<User> = listOf(user1, user2)
+val filtered = users.filter { it.email.isNotBlank() }
+
+// Bad: Mutable state
+var currentUser: User? = null // Avoid mutable global state
+val mutableUsers = mutableListOf<User>() // Avoid unless truly needed
+```
+
+## 3. Expression Bodies and Single-Expression Functions
+
+Use expression bodies for concise, readable functions.
+
+```kotlin
+// Good: Expression body
+fun isAdult(age: Int): Boolean = age >= 18
+
+fun formatFullName(first: String, last: String): String =
+    "$first $last".trim()
+
+fun User.displayName(): String =
+    name.ifBlank { email.substringBefore('@') }
+
+// Good: When as expression
+fun statusMessage(code: Int): String = when (code) {
+    200 -> "OK"
+    404 -> "Not Found"
+    500 -> "Internal Server Error"
+    else -> "Unknown status: $code"
+}
+
+// Bad: Unnecessary block body
+fun isAdult(age: Int): Boolean {
+    return age >= 18
+}
+```
+
+## 4. Data Classes for Value Objects
+
+Use data classes for types that primarily hold data.
+
+```kotlin
+// Good: Data class with copy, equals, hashCode, toString
+data class CreateUserRequest(
+    val name: String,
+    val email: String,
+    val role: Role = Role.USER,
+)
+
+// Good: Value class for type safety (zero overhead at runtime)
+@JvmInline
+value class UserId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "UserId cannot be blank" }
+    }
+}
+
+@JvmInline
+value class Email(val value: String) {
+    init {
+        require('@' in value) { "Invalid email: $value" }
+    }
+}
+
+fun getUser(id: UserId): User = userRepository.findById(id)
+```
+
+## Scope Functions
+
+### When to Use Each
+
+```kotlin
+// let: Transform nullable or scoped result
+val length: Int? = name?.let { it.trim().length }
+
+// apply: Configure an object (returns the object)
+val user = User().apply {
+    name = "Alice"
+    email = "alice@example.com"
+}
+
+// also: Side effects (returns the object)
+val user = createUser(request).also { logger.info("Created user: ${it.id}") }
+
+// run: Execute a block with receiver (returns result)
+val result = connection.run {
+    prepareStatement(sql)
+    executeQuery()
+}
+
+// with: Non-extension form of run
+val csv = with(StringBuilder()) {
+    appendLine("name,email")
+    users.forEach { appendLine("${it.name},${it.email}") }
+    toString()
+}
+```
+
+### Anti-Patterns
+
+```kotlin
+// Bad: Nesting scope functions
+user?.let { u ->
+    u.address?.let { addr ->
+        addr.city?.let { city ->
+            println(city) // Hard to read
+        }
+    }
+}
+
+// Good: Chain safe calls instead
+val city = user?.address?.city
+city?.let { println(it) }
+```

--- a/.copilot/skills/kotlin-patterns/coroutines.md
+++ b/.copilot/skills/kotlin-patterns/coroutines.md
@@ -1,0 +1,118 @@
+# Coroutines & Sequences
+
+## Structured Concurrency
+
+```kotlin
+// Good: Structured concurrency with coroutineScope
+suspend fun fetchUserWithPosts(userId: String): UserProfile =
+    coroutineScope {
+        val userDeferred = async { userService.getUser(userId) }
+        val postsDeferred = async { postService.getUserPosts(userId) }
+
+        UserProfile(
+            user = userDeferred.await(),
+            posts = postsDeferred.await(),
+        )
+    }
+
+// Good: supervisorScope when children can fail independently
+suspend fun fetchDashboard(userId: String): Dashboard =
+    supervisorScope {
+        val user = async { userService.getUser(userId) }
+        val notifications = async { notificationService.getRecent(userId) }
+        val recommendations = async { recommendationService.getFor(userId) }
+
+        Dashboard(
+            user = user.await(),
+            notifications = try {
+                notifications.await()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                emptyList()
+            },
+            recommendations = try {
+                recommendations.await()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                emptyList()
+            },
+        )
+    }
+```
+
+## Flow for Reactive Streams
+
+```kotlin
+// Good: Cold flow with proper error handling
+fun observeUsers(): Flow<List<User>> = flow {
+    while (currentCoroutineContext().isActive) {
+        val users = userRepository.findAll()
+        emit(users)
+        delay(5.seconds)
+    }
+}.catch { e ->
+    logger.error("Error observing users", e)
+    emit(emptyList())
+}
+
+// Good: Flow operators
+fun searchUsers(query: Flow<String>): Flow<List<User>> =
+    query
+        .debounce(300.milliseconds)
+        .distinctUntilChanged()
+        .filter { it.length >= 2 }
+        .mapLatest { q -> userRepository.search(q) }
+        .catch { emit(emptyList()) }
+```
+
+## Cancellation and Cleanup
+
+```kotlin
+// Good: Respect cancellation
+suspend fun processItems(items: List<Item>) {
+    items.forEach { item ->
+        ensureActive() // Check cancellation before expensive work
+        processItem(item)
+    }
+}
+
+// Good: Cleanup with try/finally
+suspend fun acquireAndProcess() {
+    val resource = acquireResource()
+    try {
+        resource.process()
+    } finally {
+        withContext(NonCancellable) {
+            resource.release() // Always release, even on cancellation
+        }
+    }
+}
+```
+
+## Sequences for Lazy Evaluation
+
+```kotlin
+// Good: Use sequences for large collections with multiple operations
+val result = users.asSequence()
+    .filter { it.isActive }
+    .map { it.email }
+    .filter { it.endsWith("@company.com") }
+    .take(10)
+    .toList()
+
+// Good: Generate infinite sequences
+val fibonacci: Sequence<Long> = sequence {
+    var a = 0L
+    var b = 1L
+    while (true) {
+        yield(a)
+        val next = a + b
+        a = b
+        b = next
+    }
+}
+
+val first20 = fibonacci.take(20).toList()
+```

--- a/.copilot/skills/kotlin-patterns/dsl-and-gradle.md
+++ b/.copilot/skills/kotlin-patterns/dsl-and-gradle.md
@@ -1,0 +1,136 @@
+# DSL Builders & Gradle Kotlin DSL
+
+## Type-Safe Builders
+
+```kotlin
+// Good: DSL with @DslMarker
+@DslMarker
+annotation class HtmlDsl
+
+@HtmlDsl
+class HTML {
+    private val children = mutableListOf<Element>()
+
+    fun head(init: Head.() -> Unit) {
+        children += Head().apply(init)
+    }
+
+    fun body(init: Body.() -> Unit) {
+        children += Body().apply(init)
+    }
+
+    override fun toString(): String = children.joinToString("\n")
+}
+
+fun html(init: HTML.() -> Unit): HTML = HTML().apply(init)
+
+// Usage
+val page = html {
+    head { title("My Page") }
+    body {
+        h1("Welcome")
+        p("Hello, World!")
+    }
+}
+```
+
+## Configuration DSL
+
+```kotlin
+data class ServerConfig(
+    val host: String = "0.0.0.0",
+    val port: Int = 8080,
+    val ssl: SslConfig? = null,
+    val database: DatabaseConfig? = null,
+)
+
+data class SslConfig(val certPath: String, val keyPath: String)
+data class DatabaseConfig(val url: String, val maxPoolSize: Int = 10)
+
+class ServerConfigBuilder {
+    var host: String = "0.0.0.0"
+    var port: Int = 8080
+    private var ssl: SslConfig? = null
+    private var database: DatabaseConfig? = null
+
+    fun ssl(certPath: String, keyPath: String) {
+        ssl = SslConfig(certPath, keyPath)
+    }
+
+    fun database(url: String, maxPoolSize: Int = 10) {
+        database = DatabaseConfig(url, maxPoolSize)
+    }
+
+    fun build(): ServerConfig = ServerConfig(host, port, ssl, database)
+}
+
+fun serverConfig(init: ServerConfigBuilder.() -> Unit): ServerConfig =
+    ServerConfigBuilder().apply(init).build()
+
+// Usage
+val config = serverConfig {
+    host = "0.0.0.0"
+    port = 443
+    ssl("/certs/cert.pem", "/certs/key.pem")
+    database("jdbc:postgresql://localhost:5432/mydb", maxPoolSize = 20)
+}
+```
+
+## Gradle Kotlin DSL
+
+### build.gradle.kts Configuration
+
+```kotlin
+// Check for latest versions: https://kotlinlang.org/docs/releases.html
+plugins {
+    kotlin("jvm") version "2.3.10"
+    kotlin("plugin.serialization") version "2.3.10"
+    id("io.ktor.plugin") version "3.4.0"
+    id("org.jetbrains.kotlinx.kover") version "0.9.7"
+    id("io.gitlab.arturbosch.detekt") version "1.23.8"
+}
+
+group = "com.example"
+version = "1.0.0"
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    // Ktor
+    implementation("io.ktor:ktor-server-core:3.4.0")
+    implementation("io.ktor:ktor-server-netty:3.4.0")
+    implementation("io.ktor:ktor-server-content-negotiation:3.4.0")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:3.4.0")
+
+    // Exposed
+    implementation("org.jetbrains.exposed:exposed-core:1.0.0")
+    implementation("org.jetbrains.exposed:exposed-dao:1.0.0")
+    implementation("org.jetbrains.exposed:exposed-jdbc:1.0.0")
+    implementation("org.jetbrains.exposed:exposed-kotlin-datetime:1.0.0")
+
+    // Koin
+    implementation("io.insert-koin:koin-ktor:4.2.0")
+
+    // Coroutines
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+
+    // Testing
+    testImplementation("io.kotest:kotest-runner-junit5:6.1.4")
+    testImplementation("io.kotest:kotest-assertions-core:6.1.4")
+    testImplementation("io.kotest:kotest-property:6.1.4")
+    testImplementation("io.mockk:mockk:1.14.9")
+    testImplementation("io.ktor:ktor-server-test-host:3.4.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+detekt {
+    config.setFrom(files("config/detekt/detekt.yml"))
+    buildUponDefaultConfig = true
+}
+```

--- a/.copilot/skills/kotlin-patterns/error-handling.md
+++ b/.copilot/skills/kotlin-patterns/error-handling.md
@@ -1,0 +1,104 @@
+# Error Handling, Collections & Anti-Patterns
+
+## Error Handling Patterns
+
+### Result Type for Domain Operations
+
+```kotlin
+// Good: Use Kotlin's Result or a custom sealed class
+suspend fun createUser(request: CreateUserRequest): Result<User> = runCatching {
+    require(request.name.isNotBlank()) { "Name cannot be blank" }
+    require('@' in request.email) { "Invalid email format" }
+
+    val user = User(
+        id = UserId(UUID.randomUUID().toString()),
+        name = request.name,
+        email = Email(request.email),
+    )
+    userRepository.save(user)
+    user
+}
+
+// Good: Chain results
+val displayName = createUser(request)
+    .map { it.name }
+    .getOrElse { "Unknown" }
+```
+
+### require, check, error
+
+```kotlin
+// Good: Preconditions with clear messages
+fun withdraw(account: Account, amount: Money): Account {
+    require(amount.value > 0) { "Amount must be positive: $amount" }
+    check(account.balance >= amount) { "Insufficient balance: ${account.balance} < $amount" }
+
+    return account.copy(balance = account.balance - amount)
+}
+```
+
+## Collection Operations
+
+### Idiomatic Collection Processing
+
+```kotlin
+// Good: Chained operations
+val activeAdminEmails: List<String> = users
+    .filter { it.role == Role.ADMIN && it.isActive }
+    .sortedBy { it.name }
+    .map { it.email }
+
+// Good: Grouping and aggregation
+val usersByRole: Map<Role, List<User>> = users.groupBy { it.role }
+
+val oldestByRole: Map<Role, User?> = users.groupBy { it.role }
+    .mapValues { (_, users) -> users.minByOrNull { it.createdAt } }
+
+// Good: Associate for map creation
+val usersById: Map<UserId, User> = users.associateBy { it.id }
+
+// Good: Partition for splitting
+val (active, inactive) = users.partition { it.isActive }
+```
+
+## Anti-Patterns to Avoid
+
+```kotlin
+// Bad: Force-unwrapping nullable types
+val name = user!!.name
+
+// Bad: Platform type leakage from Java
+fun getLength(s: String) = s.length // Safe
+fun getLength(s: String?) = s?.length ?: 0 // Handle nulls from Java
+
+// Bad: Mutable data classes
+data class MutableUser(var name: String, var email: String)
+
+// Bad: Using exceptions for control flow
+try {
+    val user = findUser(id)
+} catch (e: NotFoundException) {
+    // Don't use exceptions for expected cases
+}
+
+// Good: Use nullable return or Result
+val user: User? = findUserOrNull(id)
+
+// Bad: Ignoring coroutine scope
+GlobalScope.launch { /* Avoid GlobalScope */ }
+
+// Good: Use structured concurrency
+coroutineScope {
+    launch { /* Properly scoped */ }
+}
+
+// Bad: Deeply nested scope functions
+user?.let { u ->
+    u.address?.let { a ->
+        a.city?.let { c -> process(c) }
+    }
+}
+
+// Good: Direct null-safe chain
+user?.address?.city?.let { process(it) }
+```

--- a/.copilot/skills/kotlin-patterns/type-modeling.md
+++ b/.copilot/skills/kotlin-patterns/type-modeling.md
@@ -1,0 +1,124 @@
+# Type Modeling & Extension Functions
+
+## Sealed Classes and Interfaces
+
+### Modeling Restricted Hierarchies
+
+```kotlin
+// Good: Sealed class for exhaustive when
+sealed class Result<out T> {
+    data class Success<T>(val data: T) : Result<T>()
+    data class Failure(val error: AppError) : Result<Nothing>()
+    data object Loading : Result<Nothing>()
+}
+
+fun <T> Result<T>.getOrNull(): T? = when (this) {
+    is Result.Success -> data
+    is Result.Failure -> null
+    is Result.Loading -> null
+}
+
+fun <T> Result<T>.getOrThrow(): T = when (this) {
+    is Result.Success -> data
+    is Result.Failure -> throw error.toException()
+    is Result.Loading -> throw IllegalStateException("Still loading")
+}
+```
+
+### Sealed Interfaces for API Responses
+
+```kotlin
+sealed interface ApiError {
+    val message: String
+
+    data class NotFound(override val message: String) : ApiError
+    data class Unauthorized(override val message: String) : ApiError
+    data class Validation(
+        override val message: String,
+        val field: String,
+    ) : ApiError
+    data class Internal(
+        override val message: String,
+        val cause: Throwable? = null,
+    ) : ApiError
+}
+
+fun ApiError.toStatusCode(): Int = when (this) {
+    is ApiError.NotFound -> 404
+    is ApiError.Unauthorized -> 401
+    is ApiError.Validation -> 422
+    is ApiError.Internal -> 500
+}
+```
+
+## Extension Functions
+
+### Adding Functionality Without Inheritance
+
+```kotlin
+// Good: Domain-specific extensions
+fun String.toSlug(): String =
+    lowercase()
+        .replace(Regex("[^a-z0-9\\s-]"), "")
+        .replace(Regex("\\s+"), "-")
+        .trim('-')
+
+fun Instant.toLocalDate(zone: ZoneId = ZoneId.systemDefault()): LocalDate =
+    atZone(zone).toLocalDate()
+
+// Good: Collection extensions
+fun <T> List<T>.second(): T = this[1]
+
+fun <T> List<T>.secondOrNull(): T? = getOrNull(1)
+
+// Good: Scoped extensions (not polluting global namespace)
+class UserService {
+    private fun User.isActive(): Boolean =
+        status == Status.ACTIVE && lastLogin.isAfter(Instant.now().minus(30, ChronoUnit.DAYS))
+
+    fun getActiveUsers(): List<User> = userRepository.findAll().filter { it.isActive() }
+}
+```
+
+## Delegation
+
+### Property Delegation
+
+```kotlin
+// Lazy initialization
+val expensiveData: List<User> by lazy {
+    userRepository.findAll()
+}
+
+// Observable property
+var name: String by Delegates.observable("initial") { _, old, new ->
+    logger.info("Name changed from '$old' to '$new'")
+}
+
+// Map-backed properties
+class Config(private val map: Map<String, Any?>) {
+    val host: String by map
+    val port: Int by map
+    val debug: Boolean by map
+}
+
+val config = Config(mapOf("host" to "localhost", "port" to 8080, "debug" to true))
+```
+
+### Interface Delegation
+
+```kotlin
+// Good: Delegate interface implementation
+class LoggingUserRepository(
+    private val delegate: UserRepository,
+    private val logger: Logger,
+) : UserRepository by delegate {
+    // Only override what you need to add logging to
+    override suspend fun findById(id: String): User? {
+        logger.info("Finding user by id: $id")
+        return delegate.findById(id).also {
+            logger.info("Found user: ${it?.name ?: "null"}")
+        }
+    }
+}
+```

--- a/.github/instructions/kotlin-ktor.instructions.md
+++ b/.github/instructions/kotlin-ktor.instructions.md
@@ -1,0 +1,43 @@
+---
+applyTo: "**/config/**/*.kt,**/api/**/*.kt,**/security/**/*.kt,**/metrics/**/*.kt,**/frontend/**/*.kt,**/dto/**/*.kt,**/domain/**/*.kt,**/util/**/*.kt"
+---
+
+# Kotlin/Ktor general patterns
+
+Ktor backend service on NAIS (not Rapids & Rivers, not Spring Boot). For tests see `testing.instructions.md` and the `kotest` skill.
+
+## Configuration
+
+All config access via `PropertiesConfig` singleton. See the `kotlin-app-config` skill for full HOCON layering and `@Serializable` data-class pattern.
+
+```kotlin
+val appName = PropertiesConfig.Configuration().naisAppName
+```
+
+## Ktor routing
+
+Health/metrics endpoints are unauthenticated; domain routes sit behind `authenticate(AUTHENTICATION_NAME)`. Expose: `/internal/isAlive`, `/internal/isReady`, `/internal/metrics`.
+
+## Logging
+
+- Regular messages → Logback → Grafana Loki.
+- Sensitive data (PII, case numbers, request/response bodies, tokens) → **must** use `TEAM_LOGS_MARKER`:
+
+```kotlin
+logger.error(marker = TEAM_LOGS_MARKER) { "Error for case: $caseId" }
+```
+
+## Metrics
+
+Use the `Metrics` object (Micrometer `PrometheusMeterRegistry`). Define a namespace constant matching the app name (e.g. `sokos_my_app`). Register counters via `Counter.builder()`.
+
+## Boundaries
+
+### ✅ Always
+- `PropertiesConfig` for config — never `System.getenv()` in business logic
+- `TEAM_LOGS_MARKER` for sensitive data
+
+### 🚫 Never
+- Commit `defaults.properties`
+- Log PII/request bodies without `TEAM_LOGS_MARKER`
+- Use `!!` without a preceding null check

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,47 @@
+---
+applyTo: "**/test/**/*.kt"
+---
+
+# Testing essentials
+
+Framework: **Kotest** (never JUnit) + **MockK**. Default spec style is `BehaviorSpec` (Given/When/Then/And) with Norwegian scenario text — both for unit and integration tests. Use `FunSpec` only for trivial, purely technical unit tests.
+
+For full patterns, examples, and MockK/matchers cheat sheets, invoke the **`kotest` skill**.
+
+## Hard rules
+
+- Integration tests with DB → use a database test listener with TestContainers; clear state before loading fixtures in each `Given`.
+- Integration tests with SFTP → use an SFTP test listener.
+- Any test that reaches an external HTTP client with a circuit breaker → `beforeEach { CircuitBreakerManager.circuitBreaker.reset() }`.
+- Mock HTTP clients for external service calls — never make real HTTP calls in tests.
+- For suspend functions use `coEvery` / `coVerify`; never `runBlocking` inside test blocks.
+
+## File conventions
+
+- Unit tests: `.../service/unit/*Test.kt`
+- Integration tests: `.../service/integration/*IntegrationTest.kt`, `.../database/*Test.kt`
+- SQL fixtures: `src/test/resources/SQLscript/*.sql`
+
+## Coverage audit — do this before drawing conclusions
+
+Before claiming that an area lacks tests, **always run**:
+
+```bash
+find src/test -type f -name "*.kt" | sort
+```
+
+- Never use `| head` or limit output — test files live in subcategories (`unit/`, `integration/`, `database/`, `client/`, `config/`) and are easily truncated
+- Evaluate actual file content, not just file names, before concluding on scenario coverage
+
+## Boundaries
+
+### ✅ Always
+- `BehaviorSpec` as default; Norwegian Given/When/Then text
+- Reset circuit breaker in `beforeEach` for tests reaching external services
+- Kotest matchers (`shouldBe`, `shouldHaveSize`, `shouldBeEmpty`, `with { ... }`)
+
+### 🚫 Never
+- JUnit
+- Real HTTP calls to external services in tests
+- `runBlocking` inside test blocks
+- Leak mutable state between scenarios

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,6 @@ val logstashVersion = "9.0"
 val micrometerVersion = "1.16.5"
 val kotlinLoggingVersion = "3.0.5"
 val janionVersion = "3.1.12"
-val natpryceVersion = "1.6.10.0"
 val kotestVersion = "6.1.11"
 val kotlinxSerializationVersion = "1.11.0"
 val mockOAuth2ServerVersion = "3.0.1"
@@ -58,9 +57,6 @@ dependencies {
     runtimeOnly("org.codehaus.janino:janino:$janionVersion")
     runtimeOnly("ch.qos.logback:logback-classic:$logbackVersion")
     runtimeOnly("net.logstash.logback:logstash-logback-encoder:$logstashVersion")
-
-    // Config
-    implementation("com.natpryce:konfig:$natpryceVersion")
 
     // Test
     testImplementation("io.ktor:ktor-server-test-host-jvm:$ktorVersion")

--- a/src/main/kotlin/no/nav/sokos/prosjektnavn/Application.kt
+++ b/src/main/kotlin/no/nav/sokos/prosjektnavn/Application.kt
@@ -8,6 +8,7 @@ import no.nav.sokos.prosjektnavn.config.ApplicationState
 import no.nav.sokos.prosjektnavn.config.PropertiesConfig
 import no.nav.sokos.prosjektnavn.config.applicationLifecycleConfig
 import no.nav.sokos.prosjektnavn.config.commonConfig
+import no.nav.sokos.prosjektnavn.config.mergeWithEnv
 import no.nav.sokos.prosjektnavn.config.routingConfig
 import no.nav.sokos.prosjektnavn.config.securityConfig
 
@@ -15,8 +16,10 @@ fun main() {
     embeddedServer(Netty, port = 8080, module = Application::module).start(true)
 }
 
-fun Application.module() {
-    val useAuthentication = PropertiesConfig.Configuration().useAuthentication
+private fun Application.module() {
+    PropertiesConfig.load(environment.config.mergeWithEnv())
+
+    val useAuthentication = PropertiesConfig.applicationProperties.useAuthentication
     val applicationState = ApplicationState()
 
     applicationLifecycleConfig(applicationState)

--- a/src/main/kotlin/no/nav/sokos/prosjektnavn/config/PropertiesConfig.kt
+++ b/src/main/kotlin/no/nav/sokos/prosjektnavn/config/PropertiesConfig.kt
@@ -1,65 +1,67 @@
 package no.nav.sokos.prosjektnavn.config
 
-import java.io.File
+import kotlinx.serialization.Serializable
 
-import com.natpryce.konfig.ConfigurationMap
-import com.natpryce.konfig.ConfigurationProperties
-import com.natpryce.konfig.EnvironmentVariables
-import com.natpryce.konfig.Key
-import com.natpryce.konfig.overriding
-import com.natpryce.konfig.stringType
+import com.typesafe.config.ConfigFactory
+import io.ktor.server.config.ApplicationConfig
+import io.ktor.server.config.HoconApplicationConfig
+import io.ktor.server.config.getAs
+import io.ktor.server.config.withFallback
 
 object PropertiesConfig {
-    private val defaultProperties =
-        ConfigurationMap(
-            mapOf(
-                "NAIS_APP_NAME" to "sokos-ktor-template",
-                "NAIS_NAMESPACE" to "okonomi",
-                "USE_AUTHENTICATION" to "true",
-            ),
-        )
+    lateinit var config: ApplicationConfig
+        private set
 
-    private val localDevProperties =
-        ConfigurationMap(
-            mapOf(
-                "APPLICATION_PROFILE" to Profile.LOCAL.toString(),
-                "USE_AUTHENTICATION" to "false",
-            ),
-        )
+    val applicationProperties by lazy {
+        config.property("application").getAs<ApplicationProperties>()
+    }
 
-    private val devProperties = ConfigurationMap(mapOf("APPLICATION_PROFILE" to Profile.DEV.toString()))
-    private val prodProperties = ConfigurationMap(mapOf("APPLICATION_PROFILE" to Profile.PROD.toString()))
+    val azureAdProperties by lazy {
+        config.property("azureAd").getAs<AzureAdProperties>()
+    }
 
-    private val config =
-        when (System.getenv("NAIS_CLUSTER_NAME") ?: System.getProperty("NAIS_CLUSTER_NAME")) {
-            "dev-gcp" -> ConfigurationProperties.systemProperties() overriding EnvironmentVariables() overriding devProperties overriding defaultProperties
-            "prod-gcp" -> ConfigurationProperties.systemProperties() overriding EnvironmentVariables() overriding prodProperties overriding defaultProperties
-            else ->
-                ConfigurationProperties.systemProperties() overriding EnvironmentVariables() overriding
-                    ConfigurationProperties.fromOptionalFile(
-                        File("defaults.properties"),
-                    ) overriding localDevProperties overriding defaultProperties
+    val isLocal: Boolean
+        get() = applicationProperties.isLocal
+
+    fun load(applicationConfig: ApplicationConfig) {
+        if (!::config.isInitialized) {
+            config = applicationConfig
         }
-
-    operator fun get(key: String): String = config[Key(key, stringType)]
-
-    fun getOrEmpty(key: String): String = config.getOrElse(Key(key, stringType), "")
-
-    data class Configuration(
-        val naisAppName: String = get("NAIS_APP_NAME"),
-        val profile: Profile = Profile.valueOf(get("APPLICATION_PROFILE")),
-        val useAuthentication: Boolean = get("USE_AUTHENTICATION").toBoolean(),
-        val azureAdProperties: AzureAdProperties = AzureAdProperties(),
-    )
-
-    class AzureAdProperties(
-        val clientId: String = getOrEmpty("AZURE_APP_CLIENT_ID"),
-        val wellKnownUrl: String = getOrEmpty("AZURE_APP_WELL_KNOWN_URL"),
-    )
-
-    enum class Profile {
-        LOCAL,
-        DEV,
-        PROD,
     }
 }
+
+fun ApplicationConfig.mergeWithEnv(): ApplicationConfig {
+    val hoconConfig = HoconApplicationConfig(ConfigFactory.load())
+    val environment =
+        (System.getenv("NAIS_CLUSTER_NAME") ?: System.getProperty("NAIS_CLUSTER_NAME"))
+            ?.lowercase()
+            ?.substringBefore("-")
+            ?: propertyOrNull("ktor.environment")?.getString()
+            ?: "local"
+    val environmentConfig = ApplicationConfig("application-$environment.conf")
+    return this overriding environmentConfig overriding hoconConfig
+}
+
+infix fun ApplicationConfig.overriding(other: ApplicationConfig): ApplicationConfig = this.withFallback(other)
+
+enum class Profile {
+    LOCAL,
+    DEV,
+    PROD,
+}
+
+@Serializable
+data class ApplicationProperties(
+    val profile: Profile,
+    val appName: String,
+    val namespace: String,
+    val useAuthentication: Boolean,
+) {
+    val isLocal = profile == Profile.LOCAL
+}
+
+@Serializable
+data class AzureAdProperties(
+    val clientId: String,
+    val wellKnownUrl: String,
+)

--- a/src/main/kotlin/no/nav/sokos/prosjektnavn/config/PropertiesConfig.kt
+++ b/src/main/kotlin/no/nav/sokos/prosjektnavn/config/PropertiesConfig.kt
@@ -47,6 +47,7 @@ infix fun ApplicationConfig.overriding(other: ApplicationConfig): ApplicationCon
 enum class Profile {
     LOCAL,
     DEV,
+    TEST,
     PROD,
 }
 

--- a/src/main/kotlin/no/nav/sokos/prosjektnavn/config/SecurityConfig.kt
+++ b/src/main/kotlin/no/nav/sokos/prosjektnavn/config/SecurityConfig.kt
@@ -22,7 +22,7 @@ const val AUTHENTICATION_NAME = "azureAd"
 
 fun Application.securityConfig(
     useAuthentication: Boolean,
-    azureAdProperties: PropertiesConfig.AzureAdProperties = PropertiesConfig.AzureAdProperties(),
+    azureAdProperties: AzureAdProperties = PropertiesConfig.azureAdProperties,
 ) {
     logger.info("Use authentication: $useAuthentication")
     if (useAuthentication) {
@@ -31,7 +31,7 @@ fun Application.securityConfig(
 
         authentication {
             jwt(AUTHENTICATION_NAME) {
-                realm = PropertiesConfig.Configuration().naisAppName
+                realm = PropertiesConfig.applicationProperties.appName
                 verifier(
                     jwkProvider = jwkProvider,
                     issuer = openIdMetadata.issuer,

--- a/src/main/resources/application-dev.conf
+++ b/src/main/resources/application-dev.conf
@@ -1,0 +1,5 @@
+include file("application.conf")
+
+application {
+    profile = DEV
+}

--- a/src/main/resources/application-local.conf
+++ b/src/main/resources/application-local.conf
@@ -1,0 +1,6 @@
+include file("application.conf")
+
+application {
+    profile = LOCAL
+    useAuthentication = false
+}

--- a/src/main/resources/application-prod.conf
+++ b/src/main/resources/application-prod.conf
@@ -1,0 +1,5 @@
+include file("application.conf")
+
+application {
+    profile = PROD
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,20 @@
+include file("defaults.properties")
+
+ktor {
+    environment = local
+}
+
+application {
+    appName = "sokos-ktor-template"
+    appName = ${?NAIS_APP_NAME}
+    namespace = "okonomi"
+    namespace = ${?NAIS_NAMESPACE}
+    useAuthentication = true
+}
+
+azureAd {
+    clientId = ""
+    clientId = ${?AZURE_APP_CLIENT_ID}
+    wellKnownUrl = ""
+    wellKnownUrl = ${?AZURE_APP_WELL_KNOWN_URL}
+}

--- a/src/test/kotlin/no/nav/sokos/prosjektnavn/config/PropertiesConfigTest.kt
+++ b/src/test/kotlin/no/nav/sokos/prosjektnavn/config/PropertiesConfigTest.kt
@@ -1,0 +1,32 @@
+package no.nav.sokos.prosjektnavn.config
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.server.config.ApplicationConfig
+
+internal class PropertiesConfigTest :
+    FunSpec({
+
+        beforeSpec {
+            PropertiesConfig.load(ApplicationConfig("application-test.conf"))
+        }
+
+        test("applicationProperties skal lastes fra application-test.conf") {
+            val props = PropertiesConfig.applicationProperties
+            props.profile shouldBe Profile.TEST
+            props.appName shouldBe "sokos-ktor-template"
+            props.namespace shouldBe "okonomi-test"
+            props.useAuthentication shouldBe false
+            props.isLocal shouldBe false
+        }
+
+        test("azureAdProperties skal lastes fra application-test.conf") {
+            val props = PropertiesConfig.azureAdProperties
+            props.clientId shouldBe "test-client-id"
+            props.wellKnownUrl shouldBe "test-well-known-url"
+        }
+
+        test("isLocal skal være false for TEST-profil") {
+            PropertiesConfig.isLocal shouldBe false
+        }
+    })

--- a/src/test/kotlin/no/nav/sokos/prosjektnavn/security/SecurityTest.kt
+++ b/src/test/kotlin/no/nav/sokos/prosjektnavn/security/SecurityTest.kt
@@ -1,6 +1,5 @@
 package no.nav.sokos.prosjektnavn.security
 
-import com.typesafe.config.ConfigFactory
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -9,7 +8,7 @@ import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.config.HoconApplicationConfig
+import io.ktor.server.config.ApplicationConfig
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import io.mockk.every
@@ -25,7 +24,6 @@ import no.nav.sokos.prosjektnavn.config.AzureAdProperties
 import no.nav.sokos.prosjektnavn.config.PropertiesConfig
 import no.nav.sokos.prosjektnavn.config.authenticate
 import no.nav.sokos.prosjektnavn.config.commonConfig
-import no.nav.sokos.prosjektnavn.config.mergeWithEnv
 import no.nav.sokos.prosjektnavn.config.securityConfig
 import no.nav.sokos.prosjektnavn.domain.DummyDomain
 import no.nav.sokos.prosjektnavn.service.DummyService
@@ -43,7 +41,7 @@ internal class SecurityTest :
     FunSpec({
 
         beforeSpec {
-            PropertiesConfig.load(HoconApplicationConfig(ConfigFactory.load()).mergeWithEnv())
+            PropertiesConfig.load(ApplicationConfig("application-test.conf"))
         }
 
         test("forespørsel uten token skal returnere 401") {

--- a/src/test/kotlin/no/nav/sokos/prosjektnavn/security/SecurityTest.kt
+++ b/src/test/kotlin/no/nav/sokos/prosjektnavn/security/SecurityTest.kt
@@ -1,5 +1,6 @@
 package no.nav.sokos.prosjektnavn.security
 
+import com.typesafe.config.ConfigFactory
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -8,6 +9,7 @@ import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.config.HoconApplicationConfig
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import io.mockk.every
@@ -19,9 +21,11 @@ import no.nav.security.mock.oauth2.withMockOAuth2Server
 import no.nav.sokos.prosjektnavn.api.API_BASE_PATH
 import no.nav.sokos.prosjektnavn.api.dummyApi
 import no.nav.sokos.prosjektnavn.config.AUTHENTICATION_NAME
+import no.nav.sokos.prosjektnavn.config.AzureAdProperties
 import no.nav.sokos.prosjektnavn.config.PropertiesConfig
 import no.nav.sokos.prosjektnavn.config.authenticate
 import no.nav.sokos.prosjektnavn.config.commonConfig
+import no.nav.sokos.prosjektnavn.config.mergeWithEnv
 import no.nav.sokos.prosjektnavn.config.securityConfig
 import no.nav.sokos.prosjektnavn.domain.DummyDomain
 import no.nav.sokos.prosjektnavn.service.DummyService
@@ -37,6 +41,10 @@ val dummyService: DummyService = mockk()
 
 internal class SecurityTest :
     FunSpec({
+
+        beforeSpec {
+            PropertiesConfig.load(HoconApplicationConfig(ConfigFactory.load()).mergeWithEnv())
+        }
 
         test("forespørsel uten token skal returnere 401") {
             withMockOAuth2Server {
@@ -203,7 +211,7 @@ private fun MockOAuth2Server.tokenWithoutAudience() =
     ).serialize()
 
 private fun MockOAuth2Server.mockAuthConfig() =
-    PropertiesConfig.AzureAdProperties(
+    AzureAdProperties(
         wellKnownUrl = wellKnownUrl("default").toString(),
         clientId = "default",
     )

--- a/src/test/resources/application-test.conf
+++ b/src/test/resources/application-test.conf
@@ -1,0 +1,15 @@
+ktor {
+    environment = test
+}
+
+application {
+    profile = TEST
+    appName = "sokos-ktor-template"
+    namespace = "okonomi-test"
+    useAuthentication = false
+}
+
+azureAd {
+    clientId = "test-client-id"
+    wellKnownUrl = "test-well-known-url"
+}


### PR DESCRIPTION
## Summary

- **Copilot skills & instructions**: Added structured skill files for Kotest (BehaviorSpec, MockK, integration testing), Kotlin patterns (null safety, immutability, sealed types, coroutines, DSL builders, error handling), Kotlin app config (HOCON layering, typed config classes), and Azure RBAC for Ktor
- **Config refactor**: Migrated from `natpryce/konfig` to HOCON-based config with Ktor's `ApplicationConfig` API. Introduced `PropertiesConfig` singleton with lazy typed properties, environment-layered `.conf` files (`local`, `dev`, `prod`, `test`), and `@Serializable` data classes for config sections
- **Coding convention boundaries**: Enforced `testApplication{}` only for API endpoint tests, banned IOC/DI frameworks (Koin, Spring) and ORMs (Exposed, Spring Data) unless explicitly specified, mandated `navikt/kotliquery` for DB access, and established English naming with Norwegian domain words

## Changes

### Skills (`.copilot/skills/`)
- `kotest/` — BehaviorSpec patterns, integration testing (DB/SFTP listeners, mock HTTP, circuit breaker), MockK cheat sheet
- `kotlin-patterns/` — Core patterns, type modeling, coroutines, DSL/Gradle, error handling
- `kotlin-app-config/` — HOCON layering, typed config classes, PropertiesConfig singleton
- `azure-rbac-ktor/` — Azure AD RBAC reference

### Instructions (`.github/instructions/`)
- `kotlin-ktor.instructions.md` — General Ktor patterns (routing, logging, metrics)
- `testing.instructions.md` — Test framework rules and file conventions

### Application code
- Replaced `natpryce/konfig` with HOCON + `ApplicationConfig` in `PropertiesConfig.kt`
- Added `mergeWithEnv()` for environment-based config layering
- Updated `Application.kt` and `SecurityConfig.kt` to use new config API
- Added `application.conf`, `application-{local,dev,prod}.conf`, `application-test.conf`
- Added `PropertiesConfigTest` for config loading verification